### PR TITLE
fix: placement guide

### DIFF
--- a/EversenseKit/Packets/BasePacket.swift
+++ b/EversenseKit/Packets/BasePacket.swift
@@ -131,6 +131,9 @@ enum EversenseE3 {
 
 enum Eversense365 {
     enum PacketIds: UInt8 {
+        case OperationCommandId = 1
+        case OperationResponseId = 65
+
         case AuthenticateV2CommandId = 9
         case AuthenticateV2ResponseId = 11
 
@@ -157,6 +160,11 @@ enum Eversense365 {
         case ActiveAlerts = 34
         case LogRange = 56
         case LogValue = 58
+    }
+
+    enum OperationIds: UInt8 {
+        case enterDiagnosticMode = 8
+        case exitDiagnosticMode = 9
     }
 
     enum WriteIds: UInt8 {

--- a/EversenseKit/Packets/Eversense365/SetDiagnosticMode365Packet.swift
+++ b/EversenseKit/Packets/Eversense365/SetDiagnosticMode365Packet.swift
@@ -1,0 +1,29 @@
+extension Eversense365 {
+    class SetDiagnosticModeResponse {}
+
+    class SetDiagnosticModePacket: BasePacket {
+        typealias T = SetDiagnosticModeResponse
+
+        var responseType: UInt8 {
+            PacketIds.OperationResponseId.rawValue
+        }
+
+        var responseId: UInt8? {
+            enabled ? OperationIds.enterDiagnosticMode.rawValue : OperationIds.exitDiagnosticMode.rawValue
+        }
+
+        let enabled: Bool
+        init(enabled: Bool) {
+            self.enabled = enabled
+        }
+
+        func getRequestData() -> Data {
+            let data = Data([PacketIds.OperationCommandId.rawValue, responseId ?? 0])
+            return CryptoUtil.shared.encrypt(data: data)
+        }
+
+        func parseResponse(data _: Data) -> SetDiagnosticModeResponse {
+            SetDiagnosticModeResponse()
+        }
+    }
+}

--- a/EversenseKit/Packets/EversenseE3/SetDiagnosticModePacket.swift
+++ b/EversenseKit/Packets/EversenseE3/SetDiagnosticModePacket.swift
@@ -1,0 +1,35 @@
+extension EversenseE3 {
+    class SetDiagnosticModeResponse {}
+
+    class SetDiagnosticModePacket: BasePacket {
+        typealias T = SetDiagnosticModeResponse
+
+        var responseType: UInt8 {
+            enabled ? PacketIds.enterDiagnosticModeResponseId.rawValue : PacketIds.exitDiagnosticModeResponseId.rawValue
+        }
+
+        var responseId: UInt8? {
+            nil
+        }
+
+        let enabled: Bool
+        init(enabled: Bool) {
+            self.enabled = enabled
+        }
+
+        func getRequestData() -> Data {
+            var data = Data([
+                enabled ? PacketIds.enterDiagnosticModeCommandId.rawValue : PacketIds.exitDiagnosticModeCommandId.rawValue
+            ])
+
+            let checksum = BinaryOperations.generateChecksumCRC16(data: data)
+            data.append(BinaryOperations.dataFrom16Bits(value: checksum))
+
+            return data
+        }
+
+        func parseResponse(data _: Data) -> SetDiagnosticModeResponse {
+            SetDiagnosticModeResponse()
+        }
+    }
+}

--- a/EversenseKit/Packets/Transmitter365.swift
+++ b/EversenseKit/Packets/Transmitter365.swift
@@ -241,6 +241,15 @@ extension Eversense365 {
         }
     }
 
+    static func setDiagnosticMode(cgmManager: EversenseCGMManager, isEnabled: Bool) {
+        do {
+            logger.debug("sending \(isEnabled ? "enterDiagnosticModePhx2" : "exitDiagnosticModePhx2")...")
+            let _: SetDiagnosticModeResponse = try cgmManager.bluetoothManager.write(SetDiagnosticModePacket(enabled: isEnabled))
+        } catch {
+            logger.error("Failed to set diagnostic mode: \(error)")
+        }
+    }
+
     static func calibrateSensors(cgmManager: EversenseCGMManager, glucoseInMgDl: UInt16, timestamp: Date) throws {
         do {
             logger.info("Sending SetBloodGlucosePointPacket - glucose: \(glucoseInMgDl)mg/dl, timestamp: \(timestamp)")

--- a/EversenseKit/Packets/TransmitterE3.swift
+++ b/EversenseKit/Packets/TransmitterE3.swift
@@ -279,6 +279,15 @@ extension EversenseE3 {
         }
     }
 
+    static func setDiagnosticMode(cgmManager: EversenseCGMManager, isEnabled: Bool) {
+        do {
+            logger.debug("sending \(isEnabled ? "enterDiagnosticModePhx2" : "exitDiagnosticModePhx2")...")
+            let _: SetDiagnosticModeResponse = try cgmManager.bluetoothManager.write(SetDiagnosticModePacket(enabled: isEnabled))
+        } catch {
+            logger.error("Failed to set diagnostic mode: \(error)")
+        }
+    }
+
     static func writeTransmitterSettings(
         peripheralManager: PeripheralManager,
         data: TransmitterSettings

--- a/EversenseKitUI/ViewModels/Settings/PlacementGuideViewModel.swift
+++ b/EversenseKitUI/ViewModels/Settings/PlacementGuideViewModel.swift
@@ -23,6 +23,13 @@ class PlacementGuideViewModel: ObservableObject {
 
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             guard let self = self else { return }
+
+            if cgmManager.state.is365 {
+                Eversense365.setDiagnosticMode(cgmManager: cgmManager, isEnabled: true)
+            } else {
+                EversenseE3.setDiagnosticMode(cgmManager: cgmManager, isEnabled: true)
+            }
+
             self.updateSignalStrength(cgmManager: cgmManager)
         }
     }
@@ -33,6 +40,11 @@ class PlacementGuideViewModel: ObservableObject {
 
     private func updateSignalStrength(cgmManager: EversenseCGMManager) {
         guard running else {
+            if cgmManager.state.is365 {
+                Eversense365.setDiagnosticMode(cgmManager: cgmManager, isEnabled: false)
+            } else {
+                EversenseE3.setDiagnosticMode(cgmManager: cgmManager, isEnabled: false)
+            }
             return
         }
 
@@ -54,7 +66,7 @@ class PlacementGuideViewModel: ObservableObject {
             }
         }
 
-        Thread.sleep(forTimeInterval: .seconds(0.2))
+        Thread.sleep(forTimeInterval: .seconds(0.5))
         updateSignalStrength(cgmManager: cgmManager)
     }
 }

--- a/EversenseKitUI/ViewModels/Settings/PlacementGuideViewModel.swift
+++ b/EversenseKitUI/ViewModels/Settings/PlacementGuideViewModel.swift
@@ -30,6 +30,7 @@ class PlacementGuideViewModel: ObservableObject {
                 EversenseE3.setDiagnosticMode(cgmManager: cgmManager, isEnabled: true)
             }
 
+            Thread.sleep(forTimeInterval: .seconds(0.5))
             self.updateSignalStrength(cgmManager: cgmManager)
         }
     }


### PR DESCRIPTION
### Current issue:
When the user start the placement guide, the transmitter sends the same signal strength every time we read it.

### Solution:
Before starting to read the signal strength, the transmitter needs to be set in "Diagnostics mode". This forces the transmitter to actively pull the signal strength with the implant.

### Important:
I do not have an actual transmitter with implant. I tested this with the demo unit, which works fine. But this needs to be validated with an actual transmitter & implant

Closes #26 